### PR TITLE
Fix attemping to close file twice in should_use_fallback error path

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1372,6 +1372,7 @@ should_use_fallback(EFI_HANDLE image_handle)
 		 * 	 rc);
 		 */
 		uefi_call_wrapper(vh->Close, 1, vh);
+		vh = NULL;
 		goto error;
 	}
 


### PR DESCRIPTION
When fallback.efi is not present, as in the case of removable media, the
should_use_fallback error path attempts to close a file that has already
been closed and results in a hang.

Resolves: T12287
See also: #4794822
