### PR TITLE
include-binaries: Use Endless CA certificate

### DIFF
--- a/debian/source/include-binaries
+++ b/debian/source/include-binaries
@@ -1,1 +1,1 @@
-debian/canonical-uefi-ca.der
+debian/endless-ca.cer


### PR DESCRIPTION
include-binaries was still referencing Canonical CA's certificate, which is not shipped by our package.
