### PR TITLE
fallback: Label our boot entry as "Endless OS"

### DIFF
--- a/debian/BOOT.CSV.utf8
+++ b/debian/BOOT.CSV.utf8
@@ -1,1 +1,1 @@
-shim.efi,Endless,,This is the boot entry for Endless OS
+shim.efi,Endless OS,,This is the boot entry for Endless OS


### PR DESCRIPTION
We are already using this label out in the wild since this is what the
winstaller uses for the dual-boot installations. Lets keep it
consistent.

https://phabricator.endlessm.com/T14739