### PR TITLE
fallback: Avoid duplicates in BootOrder

### DIFF
--- a/fallback.c
+++ b/fallback.c
@@ -204,14 +204,16 @@ do_add_boot_option(int boot_entry_num, EFI_DEVICE_PATH *hddp,
 		return EFI_OUT_OF_RESOURCES;
 
 	int j = 0;
+	int n = 1;
 	newbootorder[0] = boot_entry_num & 0xffff;
 	if (nbootorder) {
 		for (j = 0; j < nbootorder; j++)
-			newbootorder[j+1] = bootorder[j];
+			if (bootorder[j] != boot_entry_num)
+				newbootorder[n++] = bootorder[j];
 		FreePool(bootorder);
 	}
 	bootorder = newbootorder;
-	nbootorder += 1;
+	nbootorder = n;
 #ifdef DEBUG_FALLBACK
 	Print(L"nbootorder: %d\nBootOrder: ", nbootorder);
 	for (j = 0 ; j < nbootorder ; j++)


### PR DESCRIPTION
When fallback re-uses a duplicate entry, it is likely that it is already
listed in BootOrder. In this case the re-used entry should not be copied
from the old BootOrder, and the new BootOrder size needs to be adjusted
accordingly.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

https://phabricator.endlessm.com/T16731