### PR TITLE
Revert "Enable signing of fallback and MokManager"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,10 +22,10 @@ endif
 	dh $@ --parallel
 
 override_dh_auto_build:
-	dh_auto_build -- EFI_PATH=/usr/lib VENDOR_CERT_FILE=$(cert) ENABLE_SHIM_CERT=1 ENABLE_SBSIGN=1 FALLBACK_VERBOSE_WAIT=3000000
+	dh_auto_build -- EFI_PATH=/usr/lib VENDOR_CERT_FILE=$(cert) FALLBACK_VERBOSE_WAIT=3000000
 
 override_dh_auto_install:
-	dh_auto_install -- EFIDIR=$(efidir) OSLABEL=$(oslabel) ENABLE_SHIM_CERT=1 ENABLE_SBSIGN=1
+	dh_auto_install -- EFIDIR=$(efidir) OSLABEL=$(oslabel)
 
 override_dh_fixperms:
 	dh_fixperms

--- a/debian/shim.install
+++ b/debian/shim.install
@@ -1,3 +1,3 @@
 shim*.efi /usr/lib/shim
-mm*.efi.signed /usr/lib/shim
-fb*.efi.signed /usr/lib/shim
+mm*.efi /usr/lib/shim
+fb*.efi /usr/lib/shim


### PR DESCRIPTION
This reverts commit fe42cf5e7c41dfb115a8d0cdc8cea65ffcaece47 and remove
the signed binaries from shim's install file.

We need reproducible builds for the community review which is now
required for the shim signing process.

https://phabricator.endlessm.com/T24681