### PR TITLE
Set FALLBACK_NEVER_REBOOT

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ else ifeq ($(shell dpkg-vendor --is endless && echo yes),yes)
 	dbx=debian/endless-uefi-dbx.esl
 	distributor=endless
 	oslabel="Endless OS"
-COMMON_OPTIONS ?= VENDOR_DBX_FILE=$(dbx) OSLABEL=$(oslabel) FALLBACK_VERBOSE_WAIT=3000000
+COMMON_OPTIONS ?= VENDOR_DBX_FILE=$(dbx) OSLABEL=$(oslabel) FALLBACK_VERBOSE_WAIT=3000000 FALLBACK_NEVER_REBOOT=1
 else
 	cert=debian/debian-uefi-ca.der
 	distributor=debian


### PR DESCRIPTION
This avoids entering a reboot loop with certain broken firmware, and to
have a potentially scary "Boot Option Restoration" full-screen message
shown to the user during the boot process in the 1st and 2nd boots.

https://phabricator.endlessm.com/T32528