### PR TITLE
Switch to using gcc-12

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper-compat (= 12),
 	       sbsigntool,
 	       openssl,
 	       libelf-dev,
-	       gcc-10,
+	       gcc-12,
 	       dos2unix,
 	       pesign (>= 0.112-5),
 	       xxd

--- a/debian/rules
+++ b/debian/rules
@@ -50,7 +50,7 @@ COMMON_OPTIONS += \
 	VENDOR_CERT_FILE=$(cert) \
 	EFIDIR=$(distributor) \
 	CROSS_COMPILE=$(DEB_HOST_GNU_TYPE)- \
-	CC=$(DEB_HOST_GNU_TYPE)-gcc-10 \
+	CC=$(DEB_HOST_GNU_TYPE)-gcc-12 \
 	$(NULL)
 
 $(DBX_LIST): $(DBX_HASHES)


### PR DESCRIPTION
Closes: #1022180

(cherry picked from Debian commit 65f161eefe0693635e292a76ab794a6ed8bb0b80)

As noted in Debian commit e17b0af, the shim package is built with specific gcc versions to help ensure it's reproducible during the lifetime of a Debian release. This just updates to use the current gcc in bookworm.

https://phabricator.endlessm.com/T34488